### PR TITLE
bugfix: array out of bounds occurs for certain Noah-MP options

### DIFF
--- a/phys/module_sf_noahmplsm.F
+++ b/phys/module_sf_noahmplsm.F
@@ -7153,7 +7153,7 @@ ENDIF   ! CROPTYPE == 0
 
    WD1 = 0.
    DO K = 1,NSOIL
-     WD1 = WD1 + (parameters%SMCMAX(K)-SH2O(K)) * DZSNSO(K) ! [m]
+     WD1 = WD1 + (parameters%SMCMAX(1)-SH2O(K)) * DZSNSO(K) ! [m]
    ENDDO
 
    DZFINE = 3.0 * (-ZSOIL(NSOIL)) / NFINE  
@@ -7165,8 +7165,8 @@ ENDIF   ! CROPTYPE == 0
 
    WD2 = 0.
    DO K = 1,NFINE
-     TEMP  = 1. + (ZWT-ZFINE(K))/parameters%PSISAT(K)
-     WD2   = WD2 + parameters%SMCMAX(K)*(1.-TEMP**(-1./parameters%BEXP(K)))*DZFINE
+     TEMP  = 1. + (ZWT-ZFINE(K))/parameters%PSISAT(1)
+     WD2   = WD2 + parameters%SMCMAX(1)*(1.-TEMP**(-1./parameters%BEXP(1)))*DZFINE
      IF(ABS(WD2-WD1).LE.0.01) THEN
         ZWT = ZFINE(K)
         EXIT


### PR DESCRIPTION
bugfix: array out of bounds occurs for certain Noah-MP options

TYPE: bugfix

KEYWORDS: Noah-MP

SOURCE: Michael Barlage (NCAR)

DESCRIPTION OF CHANGES:

One Noah-MP runoff option (opt_run=2) creates a 100-layer soil using soil properties from Noah-MP parameters data structure. Fix possible/likely array out of bounds by assuming homogeneous soil with depth. A more general fix should be completed later.
    
LIST OF MODIFIED FILES: 

M       phys/module_sf_noahmplsm.F

TESTS CONDUCTED:
1. Summer and winter 24-hr case
